### PR TITLE
Declare ckanext and ckanext.rating as namespace packages

### DIFF
--- a/ckanext/rating/__init__.py
+++ b/ckanext/rating/__init__.py
@@ -1,0 +1,7 @@
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
 
+    namespace_packages=['ckanext', 'ckanext.rating'],
+
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:


### PR DESCRIPTION
If the ckanext package is not declared as a namespace package the virtual environment is broken after a pip install.